### PR TITLE
feat: leaderboard for contributors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # GitHub Personal Access Token for API requests
 # Get your token from: https://github.com/settings/tokens
 # Required scopes: repo:status, public_repo
-VITE_GITHUB_TOKEN=your_github_token_here 
+GITHUB_TOKEN=your_github_token_here 

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# GitHub Personal Access Token for API requests
+# Get your token from: https://github.com/settings/tokens
+# Required scopes: repo:status, public_repo
+VITE_GITHUB_TOKEN=your_github_token_here 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+#Dont upload .env file
+.env
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A platform for learning engineering concepts in Kannada through YouTube playlist
 ## Adding a New Course
 
 1. Add course details to `src/data/courses.json`:
+
 ```json
 {
   "id": "course-id",
@@ -16,6 +17,7 @@ A platform for learning engineering concepts in Kannada through YouTube playlist
 ```
 
 2. Create a new video file at `src/data/videos/course-id.json`:
+
 ```json
 {
   "courseId": "course-id",
@@ -35,6 +37,7 @@ A platform for learning engineering concepts in Kannada through YouTube playlist
 ## Updating Existing Content
 
 1. To update course details:
+
    - Edit `src/data/courses.json`
    - Update the relevant course object
 
@@ -46,16 +49,19 @@ A platform for learning engineering concepts in Kannada through YouTube playlist
 ## Contribution Guidelines
 
 1. **Course Structure**:
+
    - Keep course IDs lowercase with hyphens (e.g., `python-basics`)
    - Use descriptive titles in both English and Kannada
    - Provide clear difficulty levels
 
 2. **Video Organization**:
+
    - Number videos sequentially (1, 2, 3...)
    - Include all available resources (notes, practice questions)
    - Use consistent video types (Theory/Practice/Project)
 
 3. **Quality Checks**:
+
    - Verify all YouTube URLs are working
    - Ensure thumbnails are high quality
    - Check for proper translations in titles/descriptions
@@ -68,9 +74,49 @@ A platform for learning engineering concepts in Kannada through YouTube playlist
 
 ## Local Development
 
+### Prerequisites
+
+1. Node.js (v16 or higher)
+2. npm or yarn
+3. Git
+4. GitHub Personal Access Token (for contributor leaderboard)
+
+### Setting up GitHub Token
+
+1. Create a GitHub Personal Access Token:
+
+   - Go to GitHub Settings > Developer settings > [Personal access tokens](https://github.com/settings/tokens)
+   - Click "Generate new token (classic)"
+   - Give it a descriptive name (e.g., "Engineering in Kannada Local Dev")
+   - Select the following scopes:
+     - `repo:status`
+     - `public_repo`
+   - Click "Generate token"
+   - **Copy the token immediately** (you won't be able to see it again)
+
+2. Create Environment Variables:
+   - Create a `.env` file in the project root
+   - Add your GitHub token:
+     ```env
+     VITE_GITHUB_TOKEN=your_github_token_here
+     ```
+   - Replace `your_github_token_here` with the token you copied
+
+### Installation
+
 ```bash
+# Clone the repository
+git clone https://github.com/chandansgowda/engineering-in-kannada.git
+
+# Navigate to project directory
+cd engineering-in-kannada
+
 # Install dependencies
 npm install
+
+# Create environment file
+cp .env.example .env
+# Edit .env and add your GitHub token
 
 # Start development server
 npm run dev
@@ -93,7 +139,7 @@ npm run build
 - Bookmark favorite videos
 - View course materials and coding exercises
 - Responsive design for all devices
-
+- Contributor leaderboard
 
 ## Technologies Used
 
@@ -103,4 +149,3 @@ npm run build
 - Tailwind CSS
 - React Router
 - Zustand (State Management)
-- Canvas Confetti (Celebration Effects) 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A platform for learning engineering concepts in Kannada through YouTube playlist
    - Create a `.env` file in the project root
    - Add your GitHub token:
      ```env
-     VITE_GITHUB_TOKEN=your_github_token_here
+     GITHUB_TOKEN=your_github_token_here
      ```
    - Replace `your_github_token_here` with the token you copied
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { HomePage } from './pages/HomePage';
-import { CoursePage } from './pages/CoursePage';
-import BackToTop from './components/BackToTop';
+import React from "react";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { HomePage } from "./pages/HomePage";
+import { CoursePage } from "./pages/CoursePage";
+import { LeaderboardPage } from "./pages/LeaderboardPage";
+import BackToTop from "./components/BackToTop";
 
 function App() {
   return (
@@ -11,15 +12,13 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/courses" element={<HomePage />} />
         <Route path="/course/:courseId" element={<CoursePage />} />
+        <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
 
-    <BackToTop />
-
+      <BackToTop />
     </BrowserRouter>
   );
 }
-
-
 
 export default App;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,21 @@
-import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import { GraduationCap, Home, BookOpen, Github, Menu, X, Youtube, Instagram } from 'lucide-react';
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import {
+  GraduationCap,
+  Home,
+  BookOpen,
+  Github,
+  Menu,
+  X,
+  Youtube,
+  Instagram,
+  Trophy,
+} from "lucide-react";
 
 export function Header() {
   const location = useLocation();
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
-  
+
   return (
     <header className="bg-dark/50 backdrop-blur-sm border-b border-white/10 sticky top-0 z-50">
       <nav className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -13,16 +23,20 @@ export function Header() {
           <div className="flex items-center">
             <Link to="/" className="flex items-center gap-2">
               <GraduationCap className="h-8 w-8 text-primary" />
-              <span className="text-xl font-bold text-white">Engineering in Kannada</span>
+              <span className="text-xl font-bold text-white">
+                Engineering in Kannada
+              </span>
             </Link>
           </div>
-          
+
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center gap-6">
             <Link
               to="/"
               className={`flex items-center gap-2 text-sm ${
-                location.pathname === '/' ? 'text-primary' : 'text-gray-300 hover:text-primary'
+                location.pathname === "/"
+                  ? "text-primary"
+                  : "text-gray-300 hover:text-primary"
               }`}
             >
               <Home className="h-4 w-4" />
@@ -31,11 +45,24 @@ export function Header() {
             <Link
               to="/courses"
               className={`flex items-center gap-2 text-sm ${
-                location.pathname.includes('/course') ? 'text-primary' : 'text-gray-300 hover:text-primary'
+                location.pathname.includes("/course")
+                  ? "text-primary"
+                  : "text-gray-300 hover:text-primary"
               }`}
             >
               <BookOpen className="h-4 w-4" />
               Courses
+            </Link>
+            <Link
+              to="/leaderboard"
+              className={`flex items-center gap-2 text-sm ${
+                location.pathname === "/leaderboard"
+                  ? "text-primary"
+                  : "text-gray-300 hover:text-primary"
+              }`}
+            >
+              <Trophy className="h-4 w-4" />
+              Leaderboard
             </Link>
             <a
               href="https://www.youtube.com/@EngineeringinKannada"
@@ -72,7 +99,11 @@ export function Header() {
             className="md:hidden p-2 text-gray-300 hover:text-primary"
             aria-label="Toggle menu"
           >
-            {isMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+            {isMenuOpen ? (
+              <X className="h-6 w-6" />
+            ) : (
+              <Menu className="h-6 w-6" />
+            )}
           </button>
         </div>
 
@@ -83,7 +114,9 @@ export function Header() {
               <Link
                 to="/"
                 className={`flex items-center gap-2 p-2 text-sm ${
-                  location.pathname === '/' ? 'text-primary' : 'text-gray-300 hover:text-primary'
+                  location.pathname === "/"
+                    ? "text-primary"
+                    : "text-gray-300 hover:text-primary"
                 }`}
                 onClick={() => setIsMenuOpen(false)}
               >
@@ -93,12 +126,26 @@ export function Header() {
               <Link
                 to="/courses"
                 className={`flex items-center gap-2 p-2 text-sm ${
-                  location.pathname.includes('/course') ? 'text-primary' : 'text-gray-300 hover:text-primary'
+                  location.pathname.includes("/course")
+                    ? "text-primary"
+                    : "text-gray-300 hover:text-primary"
                 }`}
                 onClick={() => setIsMenuOpen(false)}
               >
                 <BookOpen className="h-4 w-4" />
                 Courses
+              </Link>
+              <Link
+                to="/leaderboard"
+                className={`flex items-center gap-2 p-2 text-sm ${
+                  location.pathname === "/leaderboard"
+                    ? "text-primary"
+                    : "text-gray-300 hover:text-primary"
+                }`}
+                onClick={() => setIsMenuOpen(false)}
+              >
+                <Trophy className="h-4 w-4" />
+                Leaderboard
               </Link>
               <a
                 href="https://www.youtube.com/@EngineeringinKannada"

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -91,7 +91,7 @@ export function LeaderboardPage() {
                       scope="col"
                       className="px-6 py-4 text-right text-sm font-semibold text-white"
                     >
-                      Links
+                      Profile
                     </th>
                   </tr>
                 </thead>

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import { Header } from "../components/Header";
+import { Footer } from "../components/Footer";
+import { Github, Loader2 } from "lucide-react";
+import { fetchLeaderboardData, GitHubContributor } from "../services/github";
+
+export function LeaderboardPage() {
+  const [contributors, setContributors] = React.useState<GitHubContributor[]>(
+    []
+  );
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const loadData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await fetchLeaderboardData();
+        setContributors(data);
+      } catch (err) {
+        setError("Failed to load contributor data. Please try again later.");
+        console.error("Error loading contributors:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-dark">
+      <Header />
+      <main className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h1 className="text-3xl font-bold text-white sm:text-4xl">
+            Contributor Leaderboard
+          </h1>
+          <p className="mx-auto mt-4 max-w-2xl text-lg text-gray-300">
+            Celebrating our amazing contributors who help make engineering
+            education accessible in Kannada.
+          </p>
+        </div>
+
+        {loading ? (
+          <div className="flex justify-center items-center min-h-[400px]">
+            <Loader2 className="h-8 w-8 text-primary animate-spin" />
+          </div>
+        ) : error ? (
+          <div className="text-center p-8 bg-red-500/10 rounded-xl border border-red-500/20">
+            <p className="text-red-400">{error}</p>
+          </div>
+        ) : (
+          <div className="mt-8 overflow-hidden rounded-xl bg-white/10 backdrop-blur-sm border border-white/20">
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-white/10">
+                <thead>
+                  <tr>
+                    <th
+                      scope="col"
+                      className="px-6 py-4 text-left text-sm font-semibold text-white"
+                    >
+                      Rank
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-4 text-left text-sm font-semibold text-white"
+                    >
+                      Contributor
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-4 text-center text-sm font-semibold text-white"
+                    >
+                      PRs
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-4 text-center text-sm font-semibold text-white"
+                    >
+                      Issues
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-4 text-center text-sm font-semibold text-white"
+                    >
+                      Commits
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-4 text-right text-sm font-semibold text-white"
+                    >
+                      Links
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/10">
+                  {contributors.map((contributor, index) => (
+                    <tr key={contributor.github} className="hover:bg-white/5">
+                      <td className="whitespace-nowrap px-6 py-4">
+                        <div className="flex items-center">
+                          <span
+                            className={`inline-flex items-center justify-center h-8 w-8 rounded-full ${
+                              index === 0
+                                ? "bg-yellow-500/20 text-yellow-500"
+                                : index === 1
+                                ? "bg-gray-400/20 text-gray-400"
+                                : index === 2
+                                ? "bg-amber-600/20 text-amber-600"
+                                : "bg-white/10 text-gray-400"
+                            } text-sm font-semibold`}
+                          >
+                            #{index + 1}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4">
+                        <div className="flex items-center">
+                          <img
+                            src={contributor.profileImage}
+                            alt={contributor.name}
+                            className="h-10 w-10 rounded-full"
+                            onError={(e) => {
+                              const target = e.target as HTMLImageElement;
+                              target.src = `https://ui-avatars.com/api/?name=${encodeURIComponent(
+                                contributor.name || contributor.github
+                              )}&background=random`;
+                            }}
+                          />
+                          <div className="ml-4">
+                            <div className="font-medium text-white">
+                              {contributor.name || contributor.github}
+                            </div>
+                            <div className="text-sm text-gray-400">
+                              @{contributor.github}
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4 text-center text-sm text-gray-300">
+                        <span className="inline-flex items-center rounded-full bg-primary/20 px-2.5 py-0.5 text-sm font-medium text-primary">
+                          {contributor.prs}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4 text-center text-sm text-gray-300">
+                        <span className="inline-flex items-center rounded-full bg-primary/20 px-2.5 py-0.5 text-sm font-medium text-primary">
+                          {contributor.issues}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4 text-center text-sm text-gray-300">
+                        <span className="inline-flex items-center rounded-full bg-primary/20 px-2.5 py-0.5 text-sm font-medium text-primary">
+                          {contributor.commits}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-300">
+                        <div className="flex items-center justify-end space-x-3">
+                          <a
+                            href={contributor.githubProfile}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-gray-400 hover:text-primary transition-colors"
+                          >
+                            <Github className="h-5 w-5" />
+                          </a>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,7 +1,7 @@
 const REPO_OWNER = "chandansgowda";
 const REPO_NAME = "engineering-in-kannada";
 const GITHUB_API_BASE = "https://api.github.com";
-const GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN as string;
+const GITHUB_TOKEN = import.meta.env.GITHUB_TOKEN as string;
 
 interface GitHubUser {
   login: string;
@@ -12,6 +12,8 @@ interface GitHubUser {
 interface GitHubPullRequest {
   user: GitHubUser;
   commits_url: string;
+  state: "open" | "closed";
+  merged_at: string | null;
 }
 
 interface GitHubIssue {
@@ -87,7 +89,7 @@ async function processPullRequests(
   userProfiles: Record<string, { avatar: string; name?: string }>
 ) {
   const processPromises = prsData.map(async (pr) => {
-    if (pr.user?.login) {
+    if (pr.user?.login && (pr.state === "open" || pr.merged_at)) {
       const login = pr.user.login;
       prCounts[login] = (prCounts[login] || 0) + 1;
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,0 +1,181 @@
+const REPO_OWNER = "chandansgowda";
+const REPO_NAME = "engineering-in-kannada";
+const GITHUB_API_BASE = "https://api.github.com";
+const GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN as string;
+
+interface GitHubUser {
+  login: string;
+  avatar_url: string;
+  name?: string;
+}
+
+interface GitHubPullRequest {
+  user: GitHubUser;
+  commits_url: string;
+}
+
+interface GitHubIssue {
+  user: GitHubUser;
+  assignee: GitHubUser | null;
+  assignees: GitHubUser[];
+  state: "open" | "closed";
+  pull_request?: {
+    url: string;
+  };
+  closed_at: string | null;
+}
+
+interface GitHubCommit {
+  sha: string;
+  commit: {
+    message: string;
+  };
+}
+
+export interface GitHubContributor {
+  github: string;
+  prs: number;
+  issues: number;
+  commits: number;
+  githubProfile: string;
+  profileImage: string;
+  name?: string;
+}
+
+const headers: Record<string, string> = {
+  Accept: "application/vnd.github.v3+json",
+  ...(GITHUB_TOKEN ? { Authorization: `token ${GITHUB_TOKEN}` } : {}),
+};
+
+async function fetchPullRequests(): Promise<GitHubPullRequest[]> {
+  const response = await fetch(
+    `${GITHUB_API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=all&per_page=100`,
+    { headers }
+  );
+  if (!response.ok) throw new Error("Failed to fetch pull requests");
+  return await response.json();
+}
+
+async function fetchIssues(): Promise<GitHubIssue[]> {
+  const response = await fetch(
+    `${GITHUB_API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/issues?state=closed&per_page=100`,
+    { headers }
+  );
+  if (!response.ok) throw new Error("Failed to fetch issues");
+  return await response.json();
+}
+
+async function fetchCommitsForPR(commitsUrl: string): Promise<GitHubCommit[]> {
+  const response = await fetch(commitsUrl, { headers });
+  if (!response.ok) throw new Error("Failed to fetch PR commits");
+  return await response.json();
+}
+
+async function fetchUserProfile(login: string): Promise<GitHubUser> {
+  const response = await fetch(`${GITHUB_API_BASE}/users/${login}`, {
+    headers,
+  });
+  if (!response.ok)
+    throw new Error(`Failed to fetch user profile for ${login}`);
+  return await response.json();
+}
+
+async function processPullRequests(
+  prsData: GitHubPullRequest[],
+  prCounts: Record<string, number>,
+  commitCounts: Record<string, number>,
+  userProfiles: Record<string, { avatar: string; name?: string }>
+) {
+  const processPromises = prsData.map(async (pr) => {
+    if (pr.user?.login) {
+      const login = pr.user.login;
+      prCounts[login] = (prCounts[login] || 0) + 1;
+
+      // Fetch commits count for the PR
+      const commitsData = await fetchCommitsForPR(pr.commits_url);
+      commitCounts[login] = (commitCounts[login] || 0) + commitsData.length;
+
+      // Fetch user profile if not already fetched
+      if (!userProfiles[login]) {
+        const userData = await fetchUserProfile(login);
+        userProfiles[login] = {
+          avatar: userData.avatar_url,
+          name: userData.name,
+        };
+      }
+    }
+  });
+
+  await Promise.all(processPromises);
+}
+
+function processIssues(
+  issuesData: GitHubIssue[],
+  issueCounts: Record<string, number>
+) {
+  issuesData.forEach((issue) => {
+    if (issue.pull_request || !issue.user?.login) return;
+
+    if (
+      issue.state === "closed" &&
+      (issue.assignee?.login === issue.user.login ||
+        issue.assignees.some((assignee) => assignee.login === issue.user.login))
+    ) {
+      const login = issue.user.login;
+      issueCounts[login] = (issueCounts[login] || 0) + 1;
+    }
+  });
+}
+
+function prepareContributorsData(
+  prCounts: Record<string, number>,
+  issueCounts: Record<string, number>,
+  commitCounts: Record<string, number>,
+  userProfiles: Record<string, { avatar: string; name?: string }>
+): GitHubContributor[] {
+  const allUsers = new Set([
+    ...Object.keys(prCounts),
+    ...Object.keys(issueCounts),
+  ]);
+
+  return Array.from(allUsers).map((login) => ({
+    github: login,
+    name: userProfiles[login]?.name || login,
+    prs: prCounts[login] || 0,
+    issues: issueCounts[login] || 0,
+    commits: commitCounts[login] || 0,
+    githubProfile: `https://github.com/${login}`,
+    profileImage: userProfiles[login]?.avatar || "",
+  }));
+}
+
+export async function fetchLeaderboardData(): Promise<GitHubContributor[]> {
+  try {
+    const [prsData, issuesData] = await Promise.all([
+      fetchPullRequests(),
+      fetchIssues(),
+    ]);
+
+    const prCounts: Record<string, number> = {};
+    const issueCounts: Record<string, number> = {};
+    const commitCounts: Record<string, number> = {};
+    const userProfiles: Record<string, { avatar: string; name?: string }> = {};
+
+    await processPullRequests(prsData, prCounts, commitCounts, userProfiles);
+    processIssues(issuesData, issueCounts);
+
+    const contributors = prepareContributorsData(
+      prCounts,
+      issueCounts,
+      commitCounts,
+      userProfiles
+    );
+
+    return contributors.sort(
+      (a, b) => b.prs + b.issues + b.commits - (a.prs + a.issues + a.commits)
+    );
+  } catch (error) {
+    console.error("Error fetching leaderboard:", error);
+    throw error;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,7 @@ export interface Course {
   title: string;
   description: string;
   thumbnail: string;
-  difficulty: 'Beginner' | 'Intermediate' | 'Advanced';
+  difficulty: "Beginner" | "Intermediate" | "Advanced";
   starred?: boolean;
 }
 
@@ -27,7 +27,7 @@ export interface VideoData {
 
 export interface AnnouncementItem {
   id: string;
-  type: 'quote' | 'announcement';
+  type: "quote" | "announcement";
   content: string;
   author?: string;
   isActive: boolean;
@@ -35,4 +35,20 @@ export interface AnnouncementItem {
 
 export interface AnnouncementsData {
   items: AnnouncementItem[];
+}
+
+export interface Contributor {
+  id: string;
+  name: string;
+  avatar: string;
+  prs: number;
+  issues: number;
+  commits: number;
+  githubUrl?: string;
+  linkedinUrl?: string;
+  portfolioUrl?: string;
+}
+
+export interface ContributorsData {
+  contributors: Contributor[];
 }


### PR DESCRIPTION
# Add Contributor Leaderboard : Solves issue #10 

## Overview
Added a new leaderboard page that shows real-time contributor statistics from GitHub, helping recognize community members who contribute to the project.

## Key Changes
1. New Features:
   - Added `/leaderboard` page showing contributor rankings
   - Shows PRs, Issues, and Commits for each contributor
   - Links to contributors' GitHub profiles
   - Highlights top 3 contributors

2. Technical:
   - Added GitHub API integration
   - Set up environment variables for GitHub token
   - Added leaderboard link in navigation menu

## Setup
1. Copy `.env.example` to `.env`
2. Add your GitHub token to `.env`:
   ```
   VITE_GITHUB_TOKEN=your_github_token_here
   ```

## Testing
1. Install dependencies: `npm install`
2. Start dev server: `npm run dev`
3. Visit `/leaderboard` page
4. Verify contributor data loads correctly

## Screenshots
![image](https://github.com/user-attachments/assets/84628627-8010-45b2-8155-a7ff8bfe7068)
