### PR TITLE
feat: show toast when a link doesn't exist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.3",
+        "react-toastify": "^11.0.5",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -25,7 +26,7 @@
         "eslint": "^9.9.1",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.11",
-        "globals": "^15.0.1",
+        "globals": "^15.9.0",
         "postcss": "^8.4.35",
         "react-icons": "^5.5.0",
         "tailwindcss": "^3.4.1",
@@ -1831,6 +1832,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3310,6 +3320,19 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3",
+    "react-toastify": "^11.0.5",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -3,6 +3,7 @@ import { Video } from '../types';
 import { PlayCircle, FileText, CheckCircle, Star, Code } from 'lucide-react';
 import { useProgressStore } from '../store/progress';
 import confetti from 'canvas-confetti';
+import { dispatchToast } from '../utils/toastWithCustomMessages';
 
 interface VideoCardProps {
   video: Video;
@@ -92,6 +93,15 @@ export function VideoCard({ video }: VideoCardProps) {
     toggleVideoStarred(video.id);
   };
 
+  const handleNotesAndVideoClick= (uri:string)=>{
+    if(uri===""){
+      dispatchToast("🚀 Coming Soon! ")
+      return;
+    }
+    open(uri);
+  }
+
+
   return (
     <div className="rounded-lg bg-white/10 backdrop-blur-sm border border-white/20 p-4 sm:p-6 transition-all duration-300 hover:bg-white/20">
       <div className="flex items-start justify-between">
@@ -130,24 +140,22 @@ export function VideoCard({ video }: VideoCardProps) {
         </div>
       </div>
       <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:gap-4">
-        <a
-          href={video.youtubeUrl}
-          target="_blank"
+        <button
           rel="noopener noreferrer"
           className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-dark transition-colors hover:bg-primary/80"
+          onClick={()=>handleNotesAndVideoClick(video.youtubeUrl)}
         >
           <PlayCircle className="h-4 w-4" />
           Watch Video
-        </a>
-        <a
-          href={video.notesUrl}
-          target="_blank"
+        </button>
+        <button
           rel="noopener noreferrer"
           className="inline-flex items-center justify-center gap-2 rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/20"
+          onClick={()=>handleNotesAndVideoClick(video.notesUrl)}
         >
           <FileText className="h-4 w-4" />
           View Notes
-        </a>
+        </button>
         {video.codingQuestionUrl && (
           <a
             href={video.codingQuestionUrl}

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Video } from '../types';
 import { PlayCircle, FileText, CheckCircle, Star, Code } from 'lucide-react';
 import { useProgressStore } from '../store/progress';
 import confetti from 'canvas-confetti';
 import { dispatchToast } from '../utils/toastWithCustomMessages';
+import { useBreakpoint } from '../utils/useBreakPoint';
 
 interface VideoCardProps {
   video: Video;
@@ -14,6 +15,7 @@ export function VideoCard({ video }: VideoCardProps) {
   const completed = isVideoCompleted(video.id);
   const starred = isVideoStarred(video.id);
   const checkboxRef = React.useRef<HTMLButtonElement>(null);
+  const isDesktop=useBreakpoint();
 
   const playCelebrationSound = () => {
     const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
@@ -88,6 +90,7 @@ export function VideoCard({ video }: VideoCardProps) {
     }
   };
 
+
   const handleStar = (e: React.MouseEvent) => {
     e.stopPropagation();
     toggleVideoStarred(video.id);
@@ -95,7 +98,7 @@ export function VideoCard({ video }: VideoCardProps) {
 
   const handleNotesAndVideoClick= (uri:string)=>{
     if(uri===""){
-      dispatchToast("🚀 Coming Soon! Stay tuned.")
+      dispatchToast("🚀 Coming Soon! Stay tuned.",isDesktop?"top-right":"bottom-center")
       return;
     }
     open(uri);

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -95,7 +95,7 @@ export function VideoCard({ video }: VideoCardProps) {
 
   const handleNotesAndVideoClick= (uri:string)=>{
     if(uri===""){
-      dispatchToast("🚀 Coming Soon! ")
+      dispatchToast("🚀 Coming Soon! Stay tuned.")
       return;
     }
     open(uri);

--- a/src/index.css
+++ b/src/index.css
@@ -8,5 +8,5 @@
 
 .custom-toast {
     @apply bg-dark text-white rounded-lg shadow-lg;
-
+    margin-top: 10vh;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -8,5 +8,7 @@
 
 .custom-toast {
     @apply bg-dark text-white rounded-lg shadow-lg;
+    @media (min-width: 768px) {
     margin-top: 10vh;
+    }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.custom-progress {
+    background: #FFD700;
+}
+
+.custom-toast {
+    @apply bg-dark text-white rounded-lg shadow-lg;
+
+}

--- a/src/pages/CoursePage.tsx
+++ b/src/pages/CoursePage.tsx
@@ -6,9 +6,9 @@ import { ArrowLeft } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
-import { MotivationalQuote } from '../components/MotivationalQuote';
 import { useProgressStore } from '../store/progress';
 import { Video } from '../types';
+import { ToastContainer } from 'react-toastify';
 
 // Create a component to render the video list
 const VideoList = React.lazy(() => {
@@ -33,6 +33,9 @@ const VideoList = React.lazy(() => {
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold text-white">Progress: {Math.round(progress)}%</h3>
           <div className="h-2 w-32 rounded-full bg-white/10">
+          <ToastContainer
+          toastClassName={'custom-toast'}
+          />
             <div
               className="h-full rounded-full bg-primary transition-all duration-300"
               style={{ width: `${progress}%` }}

--- a/src/utils/toastWithCustomMessages.ts
+++ b/src/utils/toastWithCustomMessages.ts
@@ -1,0 +1,16 @@
+import { Bounce, toast } from 'react-toastify';
+
+export const dispatchToast=(message:string)=>{
+    toast(message, {
+        position: 'top-right',
+        autoClose: 2000,
+        hideProgressBar: false,
+        closeOnClick: false,
+        pauseOnHover: true,
+        draggable: true,
+        progress: undefined,
+        theme: 'dark',
+        transition: Bounce,
+        progressClassName: 'custom-progress',
+    });
+}

--- a/src/utils/toastWithCustomMessages.ts
+++ b/src/utils/toastWithCustomMessages.ts
@@ -1,8 +1,9 @@
-import { Bounce, toast } from 'react-toastify';
+import { Bounce, toast, ToastPosition } from 'react-toastify';
 
-export const dispatchToast=(message:string)=>{
+
+export const dispatchToast=(message:string,position:ToastPosition)=>{
     toast(message, {
-        position: 'top-right',
+        position: position,
         autoClose: 2000,
         hideProgressBar: false,
         closeOnClick: false,

--- a/src/utils/useBreakPoint.ts
+++ b/src/utils/useBreakPoint.ts
@@ -1,0 +1,17 @@
+// hooks/useBreakpoint.js
+import { useEffect, useState } from 'react';
+
+export const useBreakpoint = (breakpoint = 768) => {
+  const [isDesktop, setIsDesktop] = useState(window.innerWidth >= breakpoint);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsDesktop(window.innerWidth >= breakpoint);
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [breakpoint]);
+
+  return isDesktop;
+};


### PR DESCRIPTION
Closes #20 

---
The aim is to display relevant toast messages whenever the notes URI is missing. A similar check has also been added for videos in case any are missing.

To support extensibility, the toast dispatch logic has been moved into a separate function. This allows us to reuse it for future scenarios where custom messages may be needed.

Additionally, toast colors have been customized to align with our website's design system.