### PR TITLE
Fix navigation menu inconsistency between desktop and mobile views

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -151,7 +151,7 @@ export function Header() {
                 onClick={() => setIsMenuOpen(false)}
               >
                 <Github className="h-4 w-4" />
-                GitHub
+                Contribute
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Description
This PR fixes the inconsistency in the navigation menu between desktop and mobile views. Currently, the desktop view shows "Contribute" while the mobile view shows "GitHub" for the same navigation item. This change standardizes the terminology across both views for better user experience.

## Changes made
- Modified the mobile navigation menu to display "Contribute" instead of "GitHub" to match the desktop view
- Ensured consistent icon usage across both views

## Screenshots
Before:
- Desktop view: "Contribute" link
- Mobile view: "GitHub" link

After:
- Both views now consistently show "Contribute"

## Testing
- Tested on mobile and desktop viewports
- Verified navigation functionality works as expected