### PR TITLE
fixd the issue of Scroll Position Retained When Navigating from page …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1355,14 +1355,12 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.20",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2033,8 +2031,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/debug": {
       "version": "4.3.7",

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export function ScrollToTop() {
+    useEffect(() => {
+        // Scroll to top when component mounts
+        window.scrollTo(0, 0);
+
+        // Also handle cases where the scroll might be delayed due to rendering
+        const timer = setTimeout(() => {
+            window.scrollTo(0, 0);
+        }, 100);
+
+        return () => clearTimeout(timer);
+    }, []);
+
+    // This component doesn't render anything visible
+    return null;
+}

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { ScrollToTop } from '../components/ScrollToTop'; // 🟢 Import ScrollToTop component
 import { ArrowLeft } from 'lucide-react';
 
 export const BlogPost: React.FC = () => {
@@ -14,6 +15,7 @@ export const BlogPost: React.FC = () => {
   if (!blog) {
     return (
       <div className="min-h-screen bg-dark text-white">
+        <ScrollToTop /> {/* 🟢 Add ScrollToTop component */}
         <Header />
         <div className="container mx-auto px-4 py-8">
           <h1 className="text-4xl font-bold mb-4">Blog Post Not Found</h1>
@@ -28,10 +30,11 @@ export const BlogPost: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-dark text-white">
+      <ScrollToTop /> {/* 🟢 Add ScrollToTop component */}
       <Header />
       <div className="container mx-auto px-4 py-12">
         <Link 
-          to="/blogs" 
+          to="/blogs"
           className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors mb-8"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -80,4 +83,4 @@ export const BlogPost: React.FC = () => {
       <Footer />
     </div>
   );
-}; 
+};

--- a/src/pages/Blogs.tsx
+++ b/src/pages/Blogs.tsx
@@ -4,12 +4,14 @@ import { truncateWords } from '../utils/textUtils';
 import { Calendar, User, Tag, BookOpen } from 'lucide-react';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { ScrollToTop } from '../components/ScrollToTop'; // 🟢 Import ScrollToTop component
 
 export function Blogs() {
   const blogs = getBlogPosts();
 
   return (
     <div className="min-h-screen bg-dark">
+      <ScrollToTop /> {/* 🟢 Add ScrollToTop component */}
       <Header />
       <div className="container mx-auto px-4 py-8">
         <div className="text-center mb-20">
@@ -65,4 +67,4 @@ export function Blogs() {
       <Footer />
     </div>
   );
-} 
+}

--- a/src/pages/CoursePage.tsx
+++ b/src/pages/CoursePage.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { ScrollToTop } from '../components/ScrollToTop'; // 🟢 Import ScrollToTop component
 import { useProgressStore } from '../store/progress';
 import { Video } from '../types';
 import { ToastContainer } from 'react-toastify';
@@ -61,6 +62,7 @@ export function CoursePage() {
   if (!course) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-dark">
+        <ScrollToTop /> {/* 🟢 Add ScrollToTop component */}
         <div className="text-center">
           <h2 className="text-2xl font-bold text-white">Course not found</h2>
           <Link to="/" className="mt-4 text-primary hover:text-primary/80">
@@ -73,6 +75,7 @@ export function CoursePage() {
 
   return (
     <div className="min-h-screen bg-dark">
+      <ScrollToTop /> {/* 🟢 Add ScrollToTop component */}
       <Header />
       <main className="container mx-auto px-4 py-8">
         <div className="mb-8">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,14 +4,14 @@ import { CourseCard } from '../components/CourseCard';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { AnnouncementBanner } from '../components/AnnouncementBanner';
+import { ScrollToTop } from '../components/ScrollToTop'; 
 import { Course } from '../types';
 import { useSearchStore } from '../store/search'; // 🟡 import global search
 
 export function HomePage() {
   const { query, setQuery } = useSearchStore();
   const [showSearch, setShowSearch] = useState(false);
-
-
+  
   const filteredCourses = (coursesData.courses as Course[]).filter((course) =>
     course.title.toLowerCase().includes(query.toLowerCase()) ||
     course.description.toLowerCase().includes(query.toLowerCase())
@@ -19,13 +19,14 @@ export function HomePage() {
 
   return (
     <div className="min-h-screen bg-dark">
+      <ScrollToTop /> {/* 🟢 Add the ScrollToTop component */}
       <Header />
       <main className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <div className="text-center">
           <div className="flex justify-center">
-            <img 
-              src="/images/logo.png" 
-              alt="Engineering in Kannada" 
+            <img
+              src="/images/logo.png"
+              alt="Engineering in Kannada"
               className="h-50 w-auto"
               onError={(e) => {
                 const target = e.target as HTMLImageElement;
@@ -35,7 +36,7 @@ export function HomePage() {
           </div>
           <p className="mx-auto mt-6 max-w-2xl text-lg text-gray-300">
             Quality technical education in Kannada, 
-            accessible to everyone. Start your learning journey today with my 
+            accessible to everyone. Start your learning journey today with my
             free and carefully curated content.
           </p>
         </div>
@@ -45,28 +46,28 @@ export function HomePage() {
         </div>
 
         <div className="mt-16">
-        <div className="flex items-center justify-between">
-  <h2 className="text-2xl font-bold text-white">Available Courses</h2>
-  <div className="flex items-center space-x-2">
-    <button
-      onClick={() => setShowSearch((prev) => !prev)}
-      className="text-white hover:text-yellow-400 text-xl"
-      aria-label="Search"
-    >
-      🔍
-    </button>
-    {showSearch && (
-      <input
-        type="text"
-        placeholder="Search courses..."
-        className="rounded-md px-3 py-1 bg-gray-800 text-white border border-gray-600 focus:outline-none"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
-    )}
-  </div>
-</div>
-
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold text-white">Available Courses</h2>
+            <div className="flex items-center space-x-2">
+              <button
+                onClick={() => setShowSearch((prev) => !prev)}
+                className="text-white hover:text-yellow-400 text-xl"
+                aria-label="Search"
+              >
+                🔍
+              </button>
+              {showSearch && (
+                <input
+                  type="text"
+                  placeholder="Search courses..."
+                  className="rounded-md px-3 py-1 bg-gray-800 text-white border border-gray-600 focus:outline-none"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                />
+              )}
+            </div>
+          </div>
+          
           {filteredCourses.length > 0 ? (
             <div className="mt-8 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
               {filteredCourses.map((course) => (

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
+import { ScrollToTop } from "../components/ScrollToTop"; 
 import { Github, Loader2 } from "lucide-react";
 import { fetchLeaderboardData, GitHubContributor } from "../services/github";
 
@@ -31,6 +32,7 @@ export function LeaderboardPage() {
 
   return (
     <div className="min-h-screen bg-dark">
+      <ScrollToTop /> {/* 🟢 Add ScrollToTop component */}
       <Header />
       <main className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <div className="text-center mb-12">

--- a/src/pages/LinksPage.tsx
+++ b/src/pages/LinksPage.tsx
@@ -4,6 +4,8 @@ import * as LucideIcons from 'lucide-react';
 import { ExternalLink } from 'lucide-react';
 import linksData from '../data/links.json';
 import { LinkCategory } from '../types';
+import { ScrollToTop } from "../components/ScrollToTop"; 
+
 
 // Dynamic icon component
 const DynamicIcon = ({ iconName }: { iconName: string }) => {
@@ -16,6 +18,7 @@ export function LinksPage() {
 
   return (
     <div className="min-h-screen bg-dark">
+      <ScrollToTop />
       <Header />
       <div className="container mx-auto px-4 py-12">
         <div className="max-w-6xl mx-auto">


### PR DESCRIPTION
Issue Description
When navigating from the homepage to a specific card page (or between any pages), the scroll position from the previous page was retained. This caused users to land in the middle or bottom of the new page instead of being scrolled to the top, creating a confusing user experience.

Solution
Created a reusable ScrollToTop component that automatically scrolls to the top of the page when a component mounts, ensuring consistent navigation behavior across the application.

Changes Made
New Files

src/components/ScrollToTop.jsx - Reusable component that handles automatic scroll-to-top functionality

Modified Files

src/pages/HomePage.jsx - Added ScrollToTop component
src/pages/Blogs.jsx - Added ScrollToTop component
src/pages/BlogPost.jsx - Added ScrollToTop component
src/pages/CoursePage.jsx - Added ScrollToTop component
src/pages/LeaderboardPage.jsx - Added ScrollToTop component

Proff -> 


https://github.com/user-attachments/assets/7bf0b8dd-75fe-4e67-95a8-95844f743322


