### PR TITLE
fix: replace placeholder.com with dummyimage.com for reliable fallback  And Feature/links improvements

### DIFF
--- a/src/data/links.json
+++ b/src/data/links.json
@@ -16,7 +16,7 @@
           "id": "instagram",
           "title": "Instagram",
           "description": "Short-form tutorials and updates",
-          "coverImage": "https://scontent-icn2-1.cdninstagram.com/v/t51.2885-19/496598769_18059721569156973_1708736289005547134_n.jpg?_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_cat=1&_nc_oc=Q6cZ2QEXWIKhzV3hihjEfnfSLqF1wa74pGP9IukNLTdItYORCaQxapGmKd3wrFTyF_7g7A4&_nc_ohc=5YLN3B-_kWYQ7kNvwG41fTs&_nc_gid=WXspB09oPD85ftHI3zaIew&edm=AEF8tYYBAAAA&ccb=7-5&oh=00_AfJR0_LTVKQRCGpdsbA2Bz5N3BNO7VM4Y8oktSmXto_vIQ&oe=68351E53&_nc_sid=1e20d2",
+          "coverImage": "https://images.unsplash.com/photo-1611262588024-d12430b98920?q=80&w=1074&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
           "url": "https://www.instagram.com/engineering_in_kannada/",
           "icon": "Instagram"
         },
@@ -24,7 +24,7 @@
           "id": "twitter",
           "title": "Twitter",
           "description": "Tech updates and announcements",
-          "coverImage": "",
+          "coverImage": "https://images.unsplash.com/photo-1679061399645-f2d8eccd7328?q=80&w=1932&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
           "url": "https://twitter.com/chandansgowdru",
           "icon": "Twitter"
         }

--- a/src/pages/LinksPage.tsx
+++ b/src/pages/LinksPage.tsx
@@ -51,7 +51,7 @@ export function LinksPage() {
                           className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-110"
                           onError={(e) => {
                             const target = e.target as HTMLImageElement;
-                            target.src = `https://via.placeholder.com/800x400?text=${link.title}`;
+                            target.src = `https://dummyimage.com/800x400/1a1a1a/ffffff&text=${encodeURIComponent(link.title)}`;
                           }}
                         />
                         <div className="absolute inset-0 bg-gradient-to-t from-dark/80 to-transparent" />


### PR DESCRIPTION
fix: #60 
### Changes Made
- Replaced the broken fallback image URL from `via.placeholder.com` to `dummyimage.com` in `LinksPage.tsx`.
- Applied `encodeURIComponent(link.title)` to support titles with spaces and special characters.
- Updated Instagram and Twitter `coverImage` links in `links.json` for better quality and reliability.

### Why This Fix?
The old fallback from placeholder.com:
- Didn't render text correctly.
- Failed for titles with spaces or special characters.
- Was causing broken UI elements.

### Benefits
- Improves reliability of fallback images
- Enhances user experience with clean fallback visuals
- Reduces dependency on unstable

### Before  
![isuue16](https://github.com/user-attachments/assets/d783e892-d317-4d1f-9dbc-1db062d260a8)

### After Change 
![fix fallback img issue](https://github.com/user-attachments/assets/7b22afa9-4c19-405b-ba6a-1ffc73df403d)

### After Adding Link
![fix issue](https://github.com/user-attachments/assets/79e0675d-4075-41ff-973e-e69e146899b2)
