### PR TITLE
feature: limit leaderboard to 10 contributor 

### DIFF
--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -18,7 +18,7 @@ export function LeaderboardPage() {
         setLoading(true);
         setError(null);
         const data = await fetchLeaderboardData();
-        setContributors(data);
+        setContributors(data.slice(0, 10));
       } catch (err) {
         setError("Failed to load contributor data. Please try again later.");
         console.error("Error loading contributors:", err);


### PR DESCRIPTION
## Changes Made
- Limited leaderboard display to 10 contributors using `.slice(0, 10)`

## Technical Details  
- Data is already sorted by total contributions in `services/github.ts`
- Simple array slice operation maintains performance

Fixes #77